### PR TITLE
Fix typos across discord-api-docs repository

### DIFF
--- a/docs/dispatch/Field_Values.md
+++ b/docs/dispatch/Field_Values.md
@@ -26,7 +26,7 @@
 | sv-SE  | Swedish                 |
 | tr     | Turkish                 |
 | bg     | Bulgarian               |
-| uk     | Ukranian                |
+| uk     | Ukrainian               |
 | fi     | Finnish                 |
 | hr     | Croatian                |
 | ro     | Romanian                |

--- a/docs/game_sdk/Achievements.md
+++ b/docs/game_sdk/Achievements.md
@@ -3,7 +3,7 @@
 > info
 > Need help with the SDK? Talk to us at [dis.gd/devsupport](https://dis.gd/devsupport)
 
-There's no feeling quite like accomplishing a goal that you've set out to achieve. Is killing 1000 zombies in a game as great an achivement as climbing Mt. Everest? Of course it is, and I didn't even have to leave my house. So get off my back, society.
+There's no feeling quite like accomplishing a goal that you've set out to achieve. Is killing 1000 zombies in a game as great an achievement as climbing Mt. Everest? Of course it is, and I didn't even have to leave my house. So get off my back, society.
 
 Anyway—Discord has achievements! Show your players just how successful they are.
 

--- a/docs/game_sdk/Lobbies.md
+++ b/docs/game_sdk/Lobbies.md
@@ -1074,7 +1074,7 @@ Fires when a lobby is updated.
 ```cs
 lobbyManager.OnLobbyUpdate += (lobbyID) => 
 {
-  Console.WriteLine("lobby succesfully updated: {0}", lobbyID);
+  Console.WriteLine("lobby successfully updated: {0}", lobbyID);
 };
 ```
 

--- a/docs/resources/Audit_Log.md
+++ b/docs/resources/Audit_Log.md
@@ -24,7 +24,7 @@ Whenever an admin action is performed on the API, an entry is added to the respe
 | changes? | array of [audit log change](#DOCS_RESOURCES_AUDIT_LOG/audit-log-change-object) objects | changes made to the target_id |
 | user_id | snowflake | the user who made the changes
 | id | snowflake | id of the entry
-| action_type | [audit log event](#DOCS_RESOURCES_AUDIT_LOG/audit-log-entry-object-audit-log-events) | type of action that occured |
+| action_type | [audit log event](#DOCS_RESOURCES_AUDIT_LOG/audit-log-entry-object-audit-log-events) | type of action that occurred |
 | options? | [optional audit entry info](#DOCS_RESOURCES_AUDIT_LOG/audit-log-entry-object-optional-audit-entry-info) |  additional info for certain action types |
 | reason? | string | the reason for the change (0-512 characters) |
 

--- a/docs/rich_presence/How_To.md
+++ b/docs/rich_presence/How_To.md
@@ -276,7 +276,7 @@ All fields in the `DiscordRichPresence` object are entirely optional. Anything y
 
 Included with the launch of Rich Presence is an overhaul of Discord's Developer Dashboard. We want to make Rich Presence as easy as possible to use. Our first step is helping you ditch your CDN. You're welcome.
 
-OK, well, not entirely. But! Discord _will_ host any and all artwork that you need to have the very richest of presences. Upload an image, tag it with a key—preferrably one you can remember—and **bam**. It's ready for Rich Presence use. Head over to your [applications page](#MY_APPLICATIONS/top) to check it out!
+OK, well, not entirely. But! Discord _will_ host any and all artwork that you need to have the very richest of presences. Upload an image, tag it with a key—preferably one you can remember—and **bam**. It's ready for Rich Presence use. Head over to your [applications page](#MY_APPLICATIONS/top) to check it out!
 
 > warn
 > **Asset keys are automatically normalized to lowercase**. Be mindful of this when referring to them in your code.

--- a/docs/topics/Gateway.md
+++ b/docs/topics/Gateway.md
@@ -95,7 +95,7 @@ def on_websocket_message(msg):
 | Field     | Type    | Description                                   | Accepted Values                                                   |
 | --------- | ------- | --------------------------------------------- | ----------------------------------------------------------------- |
 | v         | integer | Gateway Version to use                        | 6 (see [Gateway versions](#DOCS_TOPICS_GATEWAY/gateway-versions)) |
-| encoding  | string  | The encoding of recieved gateway packets      | 'json' or 'etf'                                                   |
+| encoding  | string  | The encoding of received gateway packets      | 'json' or 'etf'                                                   |
 | compress? | string  | The (optional) compression of gateway packets | 'zlib-stream'                                                     |
 
 The first step in establishing connectivity to the gateway is requesting a valid websocket endpoint from the API. This can be done through either the [Get Gateway](#DOCS_TOPICS_GATEWAY/get-gateway) or the [Get Gateway Bot](#DOCS_TOPICS_GATEWAY/get-gateway-bot) endpoint.

--- a/docs/topics/Opcodes_and_Status_Codes.md
+++ b/docs/topics/Opcodes_and_Status_Codes.md
@@ -182,8 +182,8 @@ RPC is the [local Discord server](#DOCS_TOPICS_RPC/) running on localhost. Acces
 | 4009 | Invalid Token | sent when an invalid OAuth2 token is used to authorize or authenticate with |
 | 4010 | Invalid User | sent when the user id specified is invalid |
 | 5000 | OAuth2 Error | sent when a standard OAuth2 error occurred; check the data object for the OAuth 2 error information |
-| 5001 | Select Channel Timed Out | sent when an asyncronous SELECT_TEXT_CHANNEL/SELECT_VOICE_CHANNEL command times out |
-| 5002 | Get Guild Timed Out | sent when an asyncronous GET_GUILD command times out |
+| 5001 | Select Channel Timed Out | sent when an asynchronous SELECT_TEXT_CHANNEL/SELECT_VOICE_CHANNEL command times out |
+| 5002 | Get Guild Timed Out | sent when an asynchronous GET_GUILD command times out |
 | 5003 | Select Voice Force Required | sent when you try to join a user to a voice channel but the user is already in one |
 | 5004 | Capture Shortcut Already Listening | sent when you try to capture a shortcut key when already capturing one |
 

--- a/docs/topics/Voice_Connections.md
+++ b/docs/topics/Voice_Connections.md
@@ -187,7 +187,7 @@ Finally, the voice server will respond with a [Opcode 4 Session Description](#DO
 
 ## Encrypting and Sending Voice
 
-Voice data sent to discord should be encoded with [Opus](https://www.opus-codec.org/), using two channels (stereo) and a sample rate of 48kHz. Voice Data is sent using a [RTP Header](http://www.rfcreader.com/#rfc3550_line548), followed by encrypted Opus audio data. Voice encryption uses the key passed in [Opcode 4 Session Description](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/voice-opcodes) and the nonce formed with the 12 byte header appended with 12 null bytes to achive the 24 required by xsalsa20_poly1305. Discord encrypts with the [libsodium](https://download.libsodium.org/doc/) encryption library.
+Voice data sent to discord should be encoded with [Opus](https://www.opus-codec.org/), using two channels (stereo) and a sample rate of 48kHz. Voice Data is sent using a [RTP Header](http://www.rfcreader.com/#rfc3550_line548), followed by encrypted Opus audio data. Voice encryption uses the key passed in [Opcode 4 Session Description](#DOCS_TOPICS_OPCODES_AND_STATUS_CODES/voice-opcodes) and the nonce formed with the 12 byte header appended with 12 null bytes to achieve the 24 required by xsalsa20_poly1305. Discord encrypts with the [libsodium](https://download.libsodium.org/doc/) encryption library.
 
 ###### Voice Packet Structure
 


### PR DESCRIPTION
:blue_heart: Fix typos across **discord-api-docs repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
discord-api-docs/docs/dispatch/Field_Values.md:29:11: "Ukranian" is a misspelling of "Ukrainian"
discord-api-docs/docs/game_sdk/Achievements.md:6:129: "achivement" is a misspelling of "achievement"
discord-api-docs/docs/game_sdk/Lobbies.md:1077:27: "succesfully" is a misspelling of "successfully"
discord-api-docs/docs/resources/Audit_Log.md:27:123: "occured" is a misspelling of "occurred"
discord-api-docs/docs/rich_presence/How_To.md:279:159: "preferrably" is a misspelling of "preferably"
discord-api-docs/docs/topics/Gateway.md:98:40: "recieved" is a misspelling of "received"
discord-api-docs/docs/topics/Opcodes_and_Status_Codes.md:185:49: "asyncronous" is a misspelling of "asynchronous"
discord-api-docs/docs/topics/Opcodes_and_Status_Codes.md:186:44: "asyncronous" is a misspelling of "asynchronous"
discord-api-docs/docs/topics/Voice_Connections.md:190:466: "achive" is a misspelling of "achieve"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: